### PR TITLE
docs: escape {id} attribute reference in code block

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -191,7 +191,7 @@ You can also use it to create dynamic update statements:
 [source,java,subs=attributes+]
 ----
     @PUT
-    @Path("/{id}")
+    @Path("/\{id\}")
     public RestResponse<Void> update(@RestPath @Min(1) Long id, @Valid FruitPUT fruit) {
         var queryResult = new DynamicQuery()
                 .updateClauses("name", "type", "calories", "carbohydrates", "fiber", "sugars", "fat", "protein") <1>


### PR DESCRIPTION
## Summary
- Escape `{id}` in `@Path("/{id}")` inside a code block with `subs=attributes+` to prevent AsciiDoc from interpreting it as a missing attribute
- Fixes 1 warning during the quarkiverse-docs Antora build

## Test plan
- [ ] Verify the code block renders `@Path("/{id}")` correctly in the documentation